### PR TITLE
Update examples, separate credentials

### DIFF
--- a/.dangerous-files
+++ b/.dangerous-files
@@ -1,0 +1,4 @@
+AndroidManifest.xml
+situm.config.ts
+situm.config.ts.sample
+google_api_key.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore credentials:
+situm.config.ts
+# Ignore debug folder:
+**/android/app/src/debug/

--- a/angular/.gitignore
+++ b/angular/.gitignore
@@ -14,7 +14,7 @@
 chrome-profiler-events*.json
 
 # IDEs and editors
-/.idea
+.idea/
 .project
 .classpath
 .c9/

--- a/angular/android/.idea/compiler.xml
+++ b/angular/android/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/angular/android/.idea/jarRepositories.xml
+++ b/angular/android/.idea/jarRepositories.xml
@@ -31,5 +31,15 @@
       <option name="name" value="maven" />
       <option name="url" value="https://repo.situm.com/artifactory/libs-release-local" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven3" />
+      <option name="name" value="maven3" />
+      <option name="url" value="https://maven.google.com" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven2" />
+      <option name="name" value="maven2" />
+      <option name="url" value="https://repo.situm.es/artifactory/libs-release-local" />
+    </remote-repository>
   </component>
 </project>

--- a/angular/android/.idea/misc.xml
+++ b/angular/android/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/angular/android/app/src/main/AndroidManifest.xml
+++ b/angular/android/app/src/main/AndroidManifest.xml
@@ -13,11 +13,12 @@
     <activity
       android:name="com.example.app.MainActivity"
       android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
-      android:screenOrientation="portrait"
-      android:windowSoftInputMode="adjustPan"
+      android:exported="true"
       android:label="@string/title_activity_main"
       android:launchMode="singleTask"
-      android:theme="@style/AppTheme.NoActionBarLaunch">
+      android:screenOrientation="portrait"
+      android:theme="@style/AppTheme.NoActionBarLaunch"
+      android:windowSoftInputMode="adjustPan">
 
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
@@ -39,11 +40,11 @@
     <!-- YOUR_ANDROID_GOOGLE_MAPS_APIKEY -->
     <meta-data
       android:name="com.google.android.geo.API_KEY"
-      android:value="YOUR_ANDROID_GOOGLE_MAPS_APIKEY" />
+      android:value="@string/google_api_key" />
 
     <uses-library
       android:name="org.apache.http.legacy"
-      android:required="false"/>
+      android:required="false" />
   </application>
 
   <!-- Permissions -->

--- a/angular/android/app/src/main/assets/capacitor.plugins.json
+++ b/angular/android/app/src/main/assets/capacitor.plugins.json
@@ -1,6 +1,6 @@
 [
 	{
-		"pkg": "@capacitor-community/capacitor-googlemaps-native",
+		"pkg": "situm-capacitor-googlemaps-native",
 		"classpath": "com.hemangkumar.capacitorgooglemaps.CapacitorGoogleMaps"
 	},
 	{

--- a/angular/android/app/src/main/res/values/google_api_key.xml
+++ b/angular/android/app/src/main/res/values/google_api_key.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="google_api_key">YOUR-GOOGLE-API-KEY</string>
+</resources>

--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { SitumWayfinding } from 'situm-capacitor-plugin-wayfinding';
+import { SitumConfig } from 'src/situm.config';
 
 @Component({
   selector: 'app-root',
@@ -30,11 +31,11 @@ export class AppComponent {
     try {
       // LibrarySettings:
       const librarySettings = {
-        user: "YOUR_SITUM_USER",
-        apiKey: "YOUR_SITUM_APIKEY",
-        iosGoogleMapsApiKey: "YOUR_IOS_GOOGLE_MAPS_APIKEY",
-        buildingId : "YOUR_BUILDING_ID",
-        dashboardUrl: "https://dashboard.situm.com",
+        user: SitumConfig.user,
+        apiKey: SitumConfig.apiKey,
+        iosGoogleMapsApiKey: SitumConfig.iosGoogleMapsApiKey,
+        buildingId : SitumConfig.buildingId,
+        dashboardUrl: SitumConfig.dashboardUrl,
         hasSearchView: true,
         searchViewPlaceholder: "Capacitor WYF",
         useDashboardTheme: false,

--- a/angular/src/situm.config.ts.sample
+++ b/angular/src/situm.config.ts.sample
@@ -1,0 +1,8 @@
+export class SitumConfig
+{
+    static readonly user = 'YOUR-SITUM-UER';
+    static readonly apiKey = 'YOUR-SITUM-API-KEY';
+    static readonly buildingId = 'YOUR-BUILDING-ID';
+    static readonly iosGoogleMapsApiKey = 'YOUR-GOOGLE-MAPS-API-KEY';
+    static readonly dashboardUrl = 'https://dashboard.situm.com';
+};

--- a/vue3/android/app/src/main/AndroidManifest.xml
+++ b/vue3/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:theme="@style/AppTheme">
 
         <activity
+            android:exported="true"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustPan"
@@ -45,7 +46,7 @@
 
         <!-- YOUR_ANDROID_GOOGLE_MAPS_APIKEY -->
         <meta-data android:name="com.google.android.geo.API_KEY"
-            android:value="YOUR_GOOGLE_MAPS_API_KEY"/>
+            android:value="@string/google_api_key"/>
 
         <uses-library
             android:name="org.apache.http.legacy"

--- a/vue3/android/app/src/main/assets/capacitor.config.json
+++ b/vue3/android/app/src/main/assets/capacitor.config.json
@@ -1,6 +1,6 @@
 {
 	"appId": "com.example.app",
-	"appName": "Vue 3",
+	"appName": "WYF Vue 3",
 	"bundledWebRuntime": false,
 	"npmClient": "npm",
 	"webDir": "dist"

--- a/vue3/android/app/src/main/assets/capacitor.plugins.json
+++ b/vue3/android/app/src/main/assets/capacitor.plugins.json
@@ -1,6 +1,6 @@
 [
 	{
-		"pkg": "@capacitor-community/capacitor-googlemaps-native",
+		"pkg": "situm-capacitor-googlemaps-native",
 		"classpath": "com.hemangkumar.capacitorgooglemaps.CapacitorGoogleMaps"
 	},
 	{

--- a/vue3/android/app/src/main/res/values/google_api_key.xml
+++ b/vue3/android/app/src/main/res/values/google_api_key.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <string name="google_api_key">YOUR-GOOGLE-API-KEY</string>
+</resources>

--- a/vue3/src/App.vue
+++ b/vue3/src/App.vue
@@ -15,6 +15,7 @@
 
 <script>
 import { SitumWayfinding } from 'situm-capacitor-plugin-wayfinding';
+import { SitumConfig } from 'situm.config';
 
 export default {
   name: 'App',
@@ -44,16 +45,16 @@ export default {
       console.log('ATAG: Will try now to create the map');
       try {
         // LibrarySettings:
-        const librarySettings = {
-          user: "YOUR_SITUM_USER",
-          apiKey: "YOUR_SITUM_APIKEY",
-          iosGoogleMapsApiKey: "YOUR_IOS_GOOGLE_MAPS_APIKEY",
-          buildingId : "YOUR_BUILDING_ID",
-          dashboardUrl: "https://dashboard.situm.com",
-          hasSearchView: true,
-          searchViewPlaceholder: "Capacitor WYF",
-          useDashboardTheme: false,
-        };
+      const librarySettings = {
+        user: SitumConfig.user,
+        apiKey: SitumConfig.apiKey,
+        iosGoogleMapsApiKey: SitumConfig.iosGoogleMapsApiKey,
+        buildingId : SitumConfig.buildingId,
+        dashboardUrl: SitumConfig.dashboardUrl,
+        hasSearchView: true,
+        searchViewPlaceholder: "Capacitor WYF",
+        useDashboardTheme: false,
+      };
         console.log(`ATAG: will call now SitumWayfinding#load(${JSON.stringify(librarySettings)})`)
         const wyfResponse = await SitumWayfinding.load(element, librarySettings);
         console.log(`ATAG: call to load finished with result: ${JSON.stringify(wyfResponse)}`);

--- a/vue3/src/situm.config.ts.sample
+++ b/vue3/src/situm.config.ts.sample
@@ -1,0 +1,8 @@
+export class SitumConfig
+{
+    static readonly user = 'YOUR-SITUM-UER';
+    static readonly apiKey = 'YOUR-SITUM-API-KEY';
+    static readonly buildingId = 'YOUR-BUILDING-ID';
+    static readonly iosGoogleMapsApiKey = 'YOUR-GOOGLE-MAPS-API-KEY';
+    static readonly dashboardUrl = 'https://dashboard.situm.com';
+};


### PR DESCRIPTION
- Actualizo os exemplos para que funcionen: estaban desactualizados, non utilizaban a dependencia de google-maps nativo correcta.
- Actualizo a versión de WYF.
- Engado as credenciais en ficheiros separados, tanto as de Situm como a apiKey de google.
- Engado .dangerous-files, para poder protexer o repo de subidas accidentais de credenciais (a través dos hooks documentados).